### PR TITLE
hometask3.1

### DIFF
--- a/admin/src/components/events/events-table-virtualized.js
+++ b/admin/src/components/events/events-table-virtualized.js
@@ -29,6 +29,7 @@ export class EventsTable extends Component {
         rowGetter={this.rowGetter}
         rowHeight={50}
         overscanRowCount={0}
+        onRowClick={this.handleRowClick}
       >
         <Column dataKey="title" width={300} />
         <Column dataKey="where" width={300} />
@@ -38,6 +39,10 @@ export class EventsTable extends Component {
   }
 
   rowGetter = ({ index }) => this.props.events[index]
+
+  handleRowClick = ({ event, index, rowData }) => {
+    this.props.handleSelect(rowData.uid)
+  }
 }
 
 export default connect(

--- a/admin/src/components/events/events-table-virtualized.test.js
+++ b/admin/src/components/events/events-table-virtualized.test.js
@@ -1,0 +1,70 @@
+import React from 'react'
+
+import { EventsTable } from './events-table-virtualized'
+import { shallow, mount } from 'enzyme'
+import Loader from '../common/loader'
+import eventsMocks from '../../mocks/conferences'
+import { Table } from 'react-virtualized'
+
+const events = eventsMocks.map((event) => ({
+  ...event,
+  uid: Math.random().toString()
+}))
+
+describe('EventsTableVirtualized', () => {
+  it('should render loader', () => {
+    const container = shallow(<EventsTable events={[]} loading />)
+
+    expect(container.contains(<Loader />)).toBe(true)
+  })
+
+  it('should render events', () => {
+    const container = mount(<EventsTable events={events} />)
+
+    expect(container.find(Table).props().rowCount).toEqual(events.length)
+
+    const rows = container.find('.ReactVirtualized__Table__row')
+    const rowsCount = rows.length
+
+    expect(rowsCount).toBeGreaterThan(0)
+
+    const firstRow = rows.first()
+
+    expect(
+      firstRow
+        .children()
+        .at(0)
+        .text()
+    ).toEqual(events[0].title)
+    expect(
+      firstRow
+        .children()
+        .at(1)
+        .text()
+    ).toEqual(events[0].where)
+    expect(
+      firstRow
+        .children()
+        .at(2)
+        .text()
+    ).toEqual(events[0].when)
+  })
+
+  it('should select an event', () => {
+    let selectedEventId = null
+
+    const container = mount(
+      <EventsTable
+        events={events}
+        handleSelect={(id) => (selectedEventId = id)}
+      />
+    )
+
+    container
+      .find('.ReactVirtualized__Table__row')
+      .first()
+      .simulate('click')
+
+    expect(selectedEventId).toEqual(events[0].uid)
+  })
+})


### PR DESCRIPTION
3.2 не получилось решить.
Во-первых `InfiniteLoader` ожидает сразу получить количество элементов `rowCount`, а firebase js sdk такого не предоставляет (я не нашёл)
Во-вторых, InfiniteLoader вызывает `loadMoreRows ({ startIndex: number, stopIndex: number })` а firebase `startAt` принимает не номер элемента(строки) а строковый ключ. Получить список ключей заранее тоже невозможно (не нашёл).